### PR TITLE
Fix epi2me-labs/wf-amplicon#9: replace tabs in reference

### DIFF
--- a/modules/local/variant-calling.nf
+++ b/modules/local/variant-calling.nf
@@ -18,7 +18,7 @@ process sanitizeRefFile {
     output: path "reference_sanitized_seqIDs.fasta"
     script:
     """
-    sed '/^>/s/:\\|\\*\\| /_/g' reference.fasta > reference_sanitized_seqIDs.fasta
+    sed '/^>/s/[:\\*\\t ]/_/g' reference.fasta > reference_sanitized_seqIDs.fasta
     """
 }
 

--- a/modules/local/variant-calling.nf
+++ b/modules/local/variant-calling.nf
@@ -8,9 +8,9 @@ include {
 
 
 process sanitizeRefFile {
-    // some tools don't like `:` or `*` in FASTA header lines lines (e.g. medaka will
-    // try to parse the sequence ID as region string if it contains `:`) --> replace
-    // them (and whitespace) with underscores
+    // some tools don't like `:`, `"`, `*`, `$`, `\` in FASTA header lines (e.g. medaka
+    // will try to parse the sequence ID as region string if it contains `:`) -->
+    // replace them (and whitespace) with underscores
     label "wfamplicon"
     cpus 1
     memory "2 GB"
@@ -18,7 +18,7 @@ process sanitizeRefFile {
     output: path "reference_sanitized_seqIDs.fasta"
     script:
     """
-    sed '/^>/s/[:\\*\\t ]/_/g' reference.fasta > reference_sanitized_seqIDs.fasta
+    sed '/^>/s/[: \" \\* \\t \\\$ \\\\]/_/g' reference.fasta > reference_sanitized_seqIDs.fasta
     """
 }
 


### PR DESCRIPTION
_Change_: Update `sanitizeRefFile` process in `modules/local/variant-calling.nf`, to replace tabs along with spaces in the description lines of reference sequences.
_Tests_: Successfully ran with the test data in `test_data`, and with the modified reference data (with tabs) that demonstrated issue #9.
_Note_: Pushed to `prerelease` branch, as `dev` branch missing.
