### PR TITLE
Sftw 3983/increase cpus for report

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -190,7 +190,7 @@ process concatTSVs {
 process makeReport {
     label "wfamplicon"
     publishDir "${params.out_dir}", mode: 'copy', pattern: "wf-amplicon-report.html"
-    cpus 1
+    cpus 8
     memory "8 GB"
     input:
         path "data/*"

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
     analyse_unclassified = false
     combine_results = false
     igv = false
+    split_ref = false
 
     // filtering + downsampling args
     min_read_length = 300

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -269,6 +269,13 @@
                     "default": false,
                     "description": "Enable to prevent sending a workflow ping."
                 },
+                "split_ref": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Split reference",
+                    "description": "Run amplicons in parallel for coverage and variant calling.",
+                    "help_text": "Processing each amplicon in parallel can lead to performance bottlenecks due to the large number of jobs submitted to the scheduler."
+                },
                 "help": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
Increasing the number of CPUs available for the `makeReport` process from 1 to 8.

It may not speed it up but worth having a go!